### PR TITLE
feat(ip): allow to use non-managed LB IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ No modules.
 | [scaleway_lb.this](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/lb) | resource |
 | [scaleway_lb_backend.this](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/lb_backend) | resource |
 | [scaleway_lb_ip.this](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/lb_ip) | resource |
+| [scaleway_lb_ip.this](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/data-sources/lb_ip) | data source |
 
 ## Inputs
 

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,10 @@
+data "scaleway_lb_ip" "this" {
+  for_each = {
+    for loadbalancer, config in local.loadbalancers :
+    loadbalancer => config
+    if !config.create_ip
+  }
+
+  ip_address = lookup(each.value.ip, "address", null)
+  ip_id      = lookup(each.value.ip, "id", null)
+}

--- a/examples/complete-lb/main.tf
+++ b/examples/complete-lb/main.tf
@@ -1,5 +1,5 @@
 module "loadbalancers" {
-  source = "../"
+  source = "../../"
 
   loadbalancers = {
     default = {

--- a/examples/lb-no-create-ip/main.tf
+++ b/examples/lb-no-create-ip/main.tf
@@ -1,0 +1,32 @@
+module "loadbalancers" {
+  source = "../../"
+
+  loadbalancers = {
+    default = {
+      type = "LB-S"
+      name = "lb-no-create-ip"
+
+      create_ip = false
+
+      ip = {
+        id = scaleway_lb_ip.this.id
+      }
+    }
+  }
+}
+
+resource "scaleway_lb_ip" "this" {}
+
+output "loadbalancers" {
+  value = module.loadbalancers.this
+}
+
+terraform {
+  required_providers {
+    scaleway = {
+      source  = "scaleway/scaleway"
+      version = "~> 2.0"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,8 +1,10 @@
 locals {
   default_loadbalancer = {
-    type     = "LB-S"
-    tags     = []
-    backends = []
+    type      = "LB-S"
+    tags      = []
+    backends  = []
+    create_ip = true
+    ip        = {}
   }
 
   loadbalancers = {

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,15 @@
 resource "scaleway_lb_ip" "this" {
-  for_each = local.loadbalancers
+  for_each = {
+    for loadbalancer, config in local.loadbalancers :
+    loadbalancer => config
+    if config.create_ip
+  }
 }
 
 resource "scaleway_lb" "this" {
   for_each = local.loadbalancers
 
-  ip_id = scaleway_lb_ip.this[each.key].id
+  ip_id = each.value.create_ip ? scaleway_lb_ip.this[each.key].id : data.scaleway_lb_ip.this[each.key].id
   name  = lookup(each.value, "name", null)
 
   type = upper(each.value["type"])

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,7 @@ output "this" {
     for loadbalancer, config in local.loadbalancers :
     loadbalancer => {
       lb    = scaleway_lb.this[loadbalancer]
-      lb_ip = scaleway_lb_ip.this[loadbalancer]
+      lb_ip = config.create_ip ? scaleway_lb_ip.this[loadbalancer] : data.scaleway_lb_ip.this[loadbalancer]
 
       backends = [
         for backend in config.backends :


### PR DESCRIPTION
- Add the `create_ip` and `ip` attributes
- Fetch LB IP from datasource

Add an example usage for the `create_ip=false` scenario.

Move examples to the `./examples/` directory.

Closes #3
